### PR TITLE
Changes to metrics calculation

### DIFF
--- a/calculate_baseline_metrics.py
+++ b/calculate_baseline_metrics.py
@@ -31,7 +31,7 @@ import pandas as pd
 import os
 import logging
 
-from claragenomics.dl4atac.train.metrics import BCE, MSE, Recall, Precision, Specificity, CorrCoef, Accuracy, AUROC, AUPRC, SpearmanCorrCoef
+from claragenomics.dl4atac.train.metrics import BCE, MSE, Recall, Precision, Specificity, CorrCoef, Accuracy, AUROC, AUPRC, SpearmanCorrCoef, F1
 from claragenomics.io.bigwigio import extract_bigwig_intervals
 
 # Set up logging
@@ -236,15 +236,9 @@ else:
             calculate_class_nums(
                 x_peaks, t, message="Bases per class at threshold {}".format(t))
             metrics = calculate_metrics([Recall(t), Precision(
-                t), Specificity(t), Accuracy(t)], x_peaks, y_peaks)
+                t), Specificity(t), Accuracy(t), F1(t)], x_peaks, y_peaks)
             print("Classification metrics at threshold {}".format(t) +
                   " : " + " | ".join([str(metric) for metric in metrics]))
-
-            # Calculate F1 score from precision and recall
-            rec = metrics[0].get()
-            prec = metrics[1].get()
-            f1 = 2*rec*prec/(rec + prec)
-            print("F1 score at threshold {} : {:7.3f}".format(t, f1))
 
     # Calculate AUC
     if args.auc is not None:

--- a/calculate_baseline_metrics.py
+++ b/calculate_baseline_metrics.py
@@ -131,7 +131,7 @@ def parse_args():
                         help='separate regression metrics for peaks and non-peaks')
     parser.add_argument('--thresholds', type=str,
                         help='threshold or list of thresholds for classification metrics')
-    parser.add_argument('--auc', type=float, help='calculate AUC metrics')
+    parser.add_argument('--auc', action='store_true', help='calculate AUC metrics')
     parser.add_argument('--intervals', type=str,
                         help='Intervals to read bigWig files')
     parser.add_argument('--sizes', type=str,

--- a/calculate_baseline_metrics.py
+++ b/calculate_baseline_metrics.py
@@ -211,7 +211,11 @@ else:
 
     # Load data
     _logger.info("Loading data for classification")
-    x_peaks = read_data_file(args.test_file, 1, intervals, dtype='float16')
+    if args.thresholds is not None:
+        x_peaks = read_data_file(args.test_file, 1, intervals, dtype='float32')
+        # fp32 is required by torch for sensitivity/specificity calculation
+    else:
+        read_data_file(args.test_file, 1, intervals, dtype='float16')
 
     # Calculate number of bases in peaks
     calculate_class_nums(y_peaks, message="Bases per class in clean data")

--- a/calculate_baseline_metrics.py
+++ b/calculate_baseline_metrics.py
@@ -131,6 +131,7 @@ def parse_args():
                         help='separate regression metrics for peaks and non-peaks')
     parser.add_argument('--thresholds', type=str,
                         help='threshold or list of thresholds for classification metrics')
+    parser.add_argument('--auc', type=float, help='calculate AUC metrics')
     parser.add_argument('--intervals', type=str,
                         help='Intervals to read bigWig files')
     parser.add_argument('--sizes', type=str,
@@ -242,8 +243,9 @@ else:
             print("F1 score at threshold {} : {:7.3f}".format(t, f1))
 
     # Calculate AUC
-    _logger.info("Calculating AUC metrics")
-    metrics = calculate_metrics([AUROC(), AUPRC()], x_peaks, y_peaks)
-    print("AUC metrics: " + " | ".join([str(metric) for metric in metrics]))
+    if args.auc is not None:
+        _logger.info("Calculating AUC metrics")
+        metrics = calculate_metrics([AUROC(), AUPRC()], x_peaks, y_peaks)
+        print("AUC metrics: " + " | ".join([str(metric) for metric in metrics]))
 
 _logger.info('Done!') 

--- a/calculate_baseline_metrics.py
+++ b/calculate_baseline_metrics.py
@@ -101,8 +101,8 @@ def read_data_file(filename, channel=None, intervals=None, pad=None):
     if os.path.splitext(filename)[1] == '.h5':
         data = h5_to_array(filename, channel, pad)
     elif os.path.splitext(filename)[1] == '.bw':
-        data = extract_bigwig_intervals(intervals, filename)
-        data = data.flatten()
+        data = extract_bigwig_intervals(intervals, filename, stack=False)
+        data = np.concatenate(data)
     # TODO: Error if file extension is neither .h5 nor .bw
     return data.astype('float32')
 

--- a/claragenomics/dl4atac/train/metrics.py
+++ b/claragenomics/dl4atac/train/metrics.py
@@ -89,8 +89,8 @@ class CorrCoef(Metric):
         y = Metric.convert_to_tensor(y)
         xm = x.mean()
         ym = y.mean()
-        x = x-xm
-        y = y-ym
+        x = x - xm
+        y = y - ym
         #x.add_(-1*xm)
         #y.add_(-1*ym)
         self.val = torch.sum(x*y) / (torch.sqrt(torch.sum(x**2))
@@ -164,6 +164,25 @@ class Precision(Metric):
             self.val = num_peak_correct / num_peak_pred
         else:
             self.val = torch.tensor(1.).cuda() if x.is_cuda else torch.tensor(1.)
+        return self.val
+
+    def better_than(self, metric):
+        if not metric: 
+            return True
+        return self.get() > metric.get()
+
+
+class F1(Metric):
+    def __init__(self, threshold):
+        super(F1, self).__init__()
+        self.threshold = threshold
+
+    def __call__(self, x, y):
+        r = Recall(self.threshold)
+        p = Precision(self.threshold)
+        rec = r(x, y)
+        prec = p(x, y)
+        self.val = 2*rec*prec/(rec + prec)
         return self.val
 
     def better_than(self, metric):

--- a/claragenomics/dl4atac/train/metrics.py
+++ b/claragenomics/dl4atac/train/metrics.py
@@ -13,7 +13,7 @@ import torch.distributed as dist
 import torch.nn.functional as F
 import sklearn.metrics
 from collections import Iterable
-import scipy.stats
+from scipy.stats import rankdata
 
 class Metric(object):
     def __init__(self):
@@ -86,11 +86,12 @@ class CorrCoef(Metric):
     def __call__(self, x, y):
         x = Metric.convert_to_tensor(x)
         y = Metric.convert_to_tensor(y)
-        x_norm = x - torch.mean(x)
-        y_norm = y - torch.mean(y)
-
-        self.val = torch.sum(x_norm * y_norm) / (torch.sqrt(torch.sum(x_norm**2))
-                                             * torch.sqrt(torch.sum(y_norm**2)))
+        xm = x.mean()
+        ym = y.mean()
+        x.add_(-1*xm)
+        y.add_(-1*ym)
+        self.val = torch.sum(x*y) / (torch.sqrt(torch.sum(x**2))
+                                             * torch.sqrt(torch.sum(y**2)))
         return self.val
 
     def better_than(self, metric):
@@ -255,9 +256,14 @@ class SpearmanCorrCoef(Metric):
     def __call__(self, x, y):
         x = Metric.convert_to_numpy(x)
         y = Metric.convert_to_numpy(y)
-        x = x.flatten()
-        y = y.flatten()
-        self.val = scipy.stats.spearmanr(y, x)[0]
+        x = np.apply_along_axis(rankdata,0,x)
+        y = np.apply_along_axis(rankdata,0,y)
+        xm = x.mean()
+        ym = y.mean()
+        np.subtract(x, xm, out=x)
+        np.subtract(y, ym, out=y)
+        self.val = np.sum(x * y) / (np.sqrt(np.sum(x**2))
+                                             * np.sqrt(np.sum(y**2)))
         return self.val
 
     def better_than(self, metric):

--- a/claragenomics/dl4atac/train/metrics.py
+++ b/claragenomics/dl4atac/train/metrics.py
@@ -89,8 +89,10 @@ class CorrCoef(Metric):
         y = Metric.convert_to_tensor(y)
         xm = x.mean()
         ym = y.mean()
-        x.add_(-1*xm)
-        y.add_(-1*ym)
+        x = x-xm
+        y = y-ym
+        #x.add_(-1*xm)
+        #y.add_(-1*ym)
         self.val = torch.sum(x*y) / (torch.sqrt(torch.sum(x**2))
                                              * torch.sqrt(torch.sum(y**2)))
         return self.val

--- a/claragenomics/dl4atac/train/metrics.py
+++ b/claragenomics/dl4atac/train/metrics.py
@@ -8,6 +8,7 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
+import numpy as np
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F

--- a/claragenomics/dl4atac/train/metrics.py
+++ b/claragenomics/dl4atac/train/metrics.py
@@ -91,8 +91,6 @@ class CorrCoef(Metric):
         ym = y.mean()
         x = x - xm
         y = y - ym
-        #x.add_(-1*xm)
-        #y.add_(-1*ym)
         self.val = torch.sum(x*y) / (torch.sqrt(torch.sum(x**2))
                                              * torch.sqrt(torch.sum(y**2)))
         return self.val

--- a/claragenomics/io/bigwigio.py
+++ b/claragenomics/io/bigwigio.py
@@ -47,8 +47,8 @@ def extract_bigwig_to_numpy(interval, bw, pad, sizes, dtype='float32'):
             right_zero_pad = np.zeros(interval[2] + pad - sizes[interval[0]])
             result = np.concatenate([result, right_zero_pad])
         assert(len(result) == interval[2] - interval[1] + 2*pad)
-    result = np.array(result, dtype=dtype)
     result = np.nan_to_num(result)
+    result = result.astype(dtype)
     return result
 
 

--- a/claragenomics/io/bigwigio.py
+++ b/claragenomics/io/bigwigio.py
@@ -21,7 +21,7 @@ import subprocess
 import os
 
 
-def extract_bigwig_to_numpy(interval, bw, pad, sizes):
+def extract_bigwig_to_numpy(interval, bw, pad, sizes, dtype='float32'):
     """
     Function to read values in an interval from a bigWig file.
     Args:
@@ -29,6 +29,7 @@ def extract_bigwig_to_numpy(interval, bw, pad, sizes):
         bw: bigWig file object
         pad(int): padding around interval
         sizes(dict): dictionary of chromosome sizes
+        dtype(str): numpy dtype to return
     Returns:
         NumPy array containing values in the interval
     """
@@ -46,12 +47,12 @@ def extract_bigwig_to_numpy(interval, bw, pad, sizes):
             right_zero_pad = np.zeros(interval[2] + pad - sizes[interval[0]])
             result = np.concatenate([result, right_zero_pad])
         assert(len(result) == interval[2] - interval[1] + 2*pad)
-    result = np.array(result, dtype='float32')
+    result = np.array(result, dtype=dtype)
     result = np.nan_to_num(result)
     return result
 
 
-def extract_bigwig_intervals(intervals_df, bwfile, stack=True, pad=None):
+def extract_bigwig_intervals(intervals_df, bwfile, stack=True, pad=None, dtype='float32'):
     """
     Function to read values in multiple intervals from a bigWig file.
     Args:
@@ -59,12 +60,13 @@ def extract_bigwig_intervals(intervals_df, bwfile, stack=True, pad=None):
         bwfile: bigWig file path
         stack (bool): if True, stack the values into a 2D NumPy array. Only works for equal-sized intervals.
         pad(int): padding to add around interval edges
+        dtype(str): numpy dtype to return
     Returns:
         NumPy array containing values in all intervals
     """
     with pyBigWig.open(bwfile) as bw:
         result = intervals_df.apply(
-            extract_bigwig_to_numpy, axis=1, args=(bw, pad, bw.chroms()))
+            extract_bigwig_to_numpy, axis=1, args=(bw, pad, bw.chroms(), dtype))
     if stack:
         result = np.stack(result)
     return result

--- a/example/run.sh
+++ b/example/run.sh
@@ -128,12 +128,13 @@ python $root_dir/calculate_baseline_metrics.py \
 python $root_dir/calculate_baseline_metrics.py \
     --label_file $out_dir/test_data.h5 --task classification \
     --test_file $out_dir/HSC.5M.chr123.10mb.peaks.bed.bw \
-    --intervals $out_dir/example.holdout_intervals.bed
+    --intervals $out_dir/example.holdout_intervals.bed \
+    --thresholds 0.5
 
 echo ""
 echo "Step 6a: Run inference on test set with default peak calling setting..."
 echo ""
-# Note: change  --weights_path to the path for your saved model!
+# Note: change --weights_path to the path for your saved model!
 python $root_dir/main.py --infer \
     --infer_files $out_dir/test_data.h5 \
     --intervals_file $out_dir/example.holdout_intervals.bed \
@@ -147,25 +148,11 @@ python $root_dir/main.py --infer \
     --task both --num_workers 0 --gen_bigwig
 
 echo ""
-echo "Step 6b: Run inference on test set without any thresholding for advanced usage..."
-echo ""
-# Note: change  --weights_path to the path for your saved model!
-python $root_dir/main.py --infer \
-    --infer_files $out_dir/test_data.h5 \
-    --intervals_file $out_dir/example.holdout_intervals.bed \
-    --sizes_file $ref_dir/hg19.auto.sizes \
-    --weights_path $out_dir/HSC.5M.model_latest/model_best.pth.tar \
-    --out_home $out_dir --label inference \
-    --result_fname HSC.5M.output.no_threshold \
-    --model resnet --nblocks 5 --nfilt 15 --width 50 --dil 8 \
-    --nblocks_cla 2 --nfilt_cla 15 --width_cla 50 --dil_cla 10 \
-    --task both --num_workers 0 --gen_bigwig
-echo ""
 echo "Step 7a: Calculate metrics for track coverage after inference..."
 echo ""
 python $root_dir/calculate_baseline_metrics.py \
     --label_file $out_dir/test_data.h5 --task regression \
-    --test_file $out_dir/inference_latest/test_data_HSC.5M.output.no_threshold.track.bw \
+    --test_file $out_dir/inference_latest/test_data_HSC.5M.output.track.bw \
     --intervals $out_dir/example.holdout_intervals.bed \
     --sizes $ref_dir/hg19.auto.sizes \
     --sep_peaks
@@ -175,7 +162,7 @@ echo "Step 7b: Calculate metrics for peak classification after inference..."
 echo ""
 python $root_dir/calculate_baseline_metrics.py \
     --label_file $out_dir/test_data.h5 --task classification \
-    --test_file $out_dir/inference_latest/test_data_HSC.5M.output.no_threshold.peaks.bw \
+    --test_file $out_dir/inference_latest/test_data_HSC.5M.output.peaks.bw \
     --intervals $out_dir/example.holdout_intervals.bed \
     --sizes $ref_dir/hg19.auto.sizes \
     --thresholds 0.5
@@ -184,17 +171,17 @@ echo ""
 echo "Step 8: Summarize peak statistics..."
 echo ""
 python $root_dir/peaksummary.py \
-    --peakbw $out_dir/inference_latest/test_data_HSC.5M.output.no_threshold.peaks.bw \
-    --trackbw $out_dir/inference_latest/test_data_HSC.5M.output.no_threshold.track.bw \
-    --prefix $out_dir/inference_latest/test_data_HSC.5M.output.no_threshold.summary \
+    --peakbw $out_dir/inference_latest/test_data_HSC.5M.output.peaks.bw \
+    --trackbw $out_dir/inference_latest/test_data_HSC.5M.output.track.bw \
+    --prefix $out_dir/inference_latest/test_data_HSC.5M.output.summary \
     --minlen 50
 
 #######
 
 echo ""
-echo "An alternative method to call peaks..."
+echo "An alternative method to call peaks (for advanced usage)..."
 echo ""
-
+# Note: change  --weights_path to the path for your saved model!
 python $root_dir/main.py --infer \
     --infer_files $out_dir/test_data.h5 \
     --intervals_file $out_dir/example.holdout_intervals.bed \
@@ -221,6 +208,7 @@ python $root_dir/main.py --infer \
     --weights_path $saved_model_dir/bulk_blood_data/5000000.7cell.resnet.5.2.15.8.50.0803.pth.tar \
     --out_home $out_dir --label inference.pretrained \
     --result_fname HSC.5M.output.pretrained \
+    --infer_threshold 0.5 \
     --model resnet --nblocks 5 --nfilt 15 --width 50 --dil 8 \
     --nblocks_cla 2 --nfilt_cla 15 --width_cla 50 --dil_cla 10 \
     --task both --num_workers 0 --gen_bigwig

--- a/main.py
+++ b/main.py
@@ -367,12 +367,12 @@ def writer(args, res_queue, prefix):
     elif args.task == "classification":
         channels = [1]
         outfiles = [os.path.join(out_base_path + ".peaks.bedGraph")]
-        rounding = [2]
+        rounding = [3]
     elif args.task == "both":
         channels = [0, 1]
         outfiles = [os.path.join(out_base_path + ".track.bedGraph"),
                     os.path.join(out_base_path + ".peaks.bedGraph")]
-        rounding = [0, 2]
+        rounding = [0, 3]
 
     # Temp dir used to save temp files during multiprocessing.
     temp_dir = tempfile.mkdtemp()


### PR DESCRIPTION
-Changes to bigwigio.py:
1. Allow reading of bigWig files to any NumPy type

-Changes to calculate_baseline_metrics.py:
1.  Removed 'task = both' option since the script has to be run separately for regression or classification
2. Allow loading from bigWig/h5 to multiple dtypes
3. Set type to fp16 for classification probabilities and int8 for classification labels when only calculating AUC; this reduced whole-genome AUC calculation time from 3hrs to 1.5 hrs
4. Calculate threshold-based classification metrics only if --threshold is provided
5. Calculate AUC metrics if --auc flag is provided.
6. Called F1 score from metrics.py

-Changes to metrics.py:
1.  Rewrote spearman correlation. The scipy spearman function fails on genome-length arrays. 
2. Added F1 score to metrics.py

-Increased rounding values for probability in main.py. This is temporary until we make this a command-line argument.

- run.sh: removed duplicate commands for inference without threshold. fixed the call to `peaksummary.py` to take thresholded peak outputs instead of non-thresholded.